### PR TITLE
move create loop/asyncHandle into constructor

### DIFF
--- a/src/NetUV.Core/Channels/EventLoop.cs
+++ b/src/NetUV.Core/Channels/EventLoop.cs
@@ -61,6 +61,8 @@ namespace NetUV.Core.Channels
             this.queue = new ConcurrentQueue<Activator>();
             this.loopState = 0;
             this.thread = new Thread(this.RunLoop);
+            this.loop = new Loop();
+            this.asyncHandle = this.loop.CreateAsync(this.OnAsync);
         }
 
         public void ScheduleStop()
@@ -115,8 +117,6 @@ namespace NetUV.Core.Channels
 
             try
             {
-                this.loop = new Loop();
-                this.asyncHandle = this.loop.CreateAsync(this.OnAsync);
                 this.loop.RunDefault();
 
                 completion.TrySetResult(true);


### PR DESCRIPTION
`RunLoop` is called later than `Schedule`(sometimes maybe)，and then will cause
```
Loop thread error System.NullReferenceException: Object reference not set to an instance of an object.
```
Just create the `loop` and `asyncHandle` in the constructor，and start it in the loop thread.